### PR TITLE
Use flask_restfull abort, enables login_required for api

### DIFF
--- a/backend/authentication.py
+++ b/backend/authentication.py
@@ -10,6 +10,7 @@ from flask import jsonify, Blueprint
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField
 from wtforms.validators import DataRequired
+from flask_restful import abort
 
 
 from .models import User
@@ -34,10 +35,11 @@ def role_required(role_name):
         @login_required  # first of all a use needs to be logged in
         def decorated_function(*args, **kwargs):
             if not current_user.has_role(role_name):
-                return jsonify(
+                return abort(
+                    401,
                     status='access_denied',
                     message=f'user lacks required role "{role_name}"'
-                ), 401
+                )
             return func(*args, **kwargs)
         return decorated_function
     return access_decorator
@@ -50,10 +52,11 @@ def load_user(id):
 
 @login.unauthorized_handler
 def handle_needs_login():
-    return jsonify(
+    return abort(
+        401,
         status='access_denied',
         message='You need to login to access this page'
-    ), 401
+    )
 
 
 class LoginForm(FlaskForm):

--- a/backend/authentication.py
+++ b/backend/authentication.py
@@ -5,12 +5,11 @@ from flask_login import (
     login_user, logout_user,
     login_required, current_user,
 )
-from flask import jsonify, Blueprint
+from flask import jsonify, Blueprint, abort, make_response
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, SubmitField
 from wtforms.validators import DataRequired
-from flask_restful import abort
 
 
 from .models import User
@@ -35,11 +34,9 @@ def role_required(role_name):
         @login_required  # first of all a use needs to be logged in
         def decorated_function(*args, **kwargs):
             if not current_user.has_role(role_name):
-                return abort(
-                    401,
-                    status='access_denied',
+                return abort(make_response(jsonify(
                     message=f'user lacks required role "{role_name}"'
-                )
+                ), 401))
             return func(*args, **kwargs)
         return decorated_function
     return access_decorator
@@ -52,11 +49,9 @@ def load_user(id):
 
 @login.unauthorized_handler
 def handle_needs_login():
-    return abort(
-        401,
-        status='access_denied',
+    return abort(make_response(jsonify(
         message='You need to login to access this page'
-    )
+    ), 401))
 
 
 class LoginForm(FlaskForm):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -64,7 +64,6 @@ def test_login_required(app, client, user):
 
     ret = client.get('/test_login_required/')
     assert ret.status_code == 401
-    assert ret.json['status'] == 'access_denied'
 
     client.post('/login/', data=LOGIN_DATA)
 
@@ -95,7 +94,6 @@ def test_roles(app, client, user):
     # test request fails when user does not have needed role
     r = client.get('/test_role_required/')
     assert r.status_code == 401
-    assert r.json['status'] == 'access_denied'
     assert r.json['message'] == 'user lacks required role "test_role"'
 
     # test user can request the endpoint no that he/she has the role


### PR DESCRIPTION
Use abort from flask_restful in `login_required` and `role_required` which makes it possible to require login for the restful views in `api`.